### PR TITLE
 Export leaks (Giving the memory we lend 😁 back to the system)

### DIFF
--- a/Execu/builtins/export.c
+++ b/Execu/builtins/export.c
@@ -6,7 +6,7 @@
 /*   By: obouizga <obouizga@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/24 15:03:56 by obouizga          #+#    #+#             */
-/*   Updated: 2022/11/06 20:37:22 by obouizga         ###   ########.fr       */
+/*   Updated: 2022/11/08 09:25:12 by obouizga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,6 +28,7 @@ void	_export(char **entries, t_envl **envl)
 				continue ;
 			entry = get_entry(entries[i]);
 			set_variable(entry[0], entry[1], envl);
+			free(entry);
 			i++;
 		}
 	}

--- a/Execu/builtins/export_utils.c
+++ b/Execu/builtins/export_utils.c
@@ -6,7 +6,7 @@
 /*   By: obouizga <obouizga@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/11/04 09:52:04 by obouizga          #+#    #+#             */
-/*   Updated: 2022/11/06 20:36:41 by obouizga         ###   ########.fr       */
+/*   Updated: 2022/11/08 10:29:17 by obouizga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,9 +35,11 @@ char	**get_entry(char *assign)
 
 	len = ft_strlen(assign);
 	i = 0;
-	entry = ft_calloc(3, sizeof(char *));
+	entry = ft_calloc(2, sizeof(char *));
 	while (assign[i] && assign[i] != '=' && assign[i] != '+')
 		entry[0] = charjoin(entry[0], assign[i++]);
+	if (!assign[i])
+		return (entry);
 	if (assign[i] == '=')
 		while (assign[++i])
 			entry[1] = charjoin(entry[1], assign[i]);
@@ -60,8 +62,12 @@ int	reset_variable(char *key, char *value, t_envl *envl)
 	{
 		if (!ft_strcmp(curr->key, key))
 		{
-			if (value && *value)
+			free(key);
+			if (value)
+			{
+				free(curr->value);
 				curr->value = value;
+			}
 			return (1);
 		}
 		curr = curr->next;

--- a/Parsing/lexer.c
+++ b/Parsing/lexer.c
@@ -6,7 +6,7 @@
 /*   By: obouizga <obouizga@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/10/09 11:11:57 by obouizga          #+#    #+#             */
-/*   Updated: 2022/10/15 18:41:41 by obouizga         ###   ########.fr       */
+/*   Updated: 2022/11/08 09:18:53 by obouizga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,7 @@ t_toklist	*lexer(char *cmd_line)
 
 	lex = init_lex(cmd_line);
 	tokens = get_tokens_list(lex);
+	free(lex);
 	return (tokens);
 }
 


### PR DESCRIPTION
This branch was about freeing unnecessary memory mainly from export BUILTIN functions,  this procedure takes well in consideration the presence of different use cases of the `export` BUILTIN. For instance, setting a new variable or resetting an existing one and so on...
`export new_variable=new_value`
`export existing_variable=new_value`
`export existing_variable`
Also we have freed the memory that was allocated to the lexer object after being done with it 